### PR TITLE
Fix: Add resource limits and quotas for cluster stability

### DIFF
--- a/flux/clusters/cumulus/applications/mailu/kustomization.yaml
+++ b/flux/clusters/cumulus/applications/mailu/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: mailu
 resources:
   - namespace.yaml
+  - resource-quota.yaml
   - postgresql-cluster.yaml
   - redis-cluster.yaml
   - repository.yaml

--- a/flux/clusters/cumulus/applications/mailu/resource-quota.yaml
+++ b/flux/clusters/cumulus/applications/mailu/resource-quota.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: compute-resources
+  namespace: mailu
+spec:
+  hard:
+    requests.cpu: "4"
+    requests.memory: 8Gi
+    limits.cpu: "8"
+    limits.memory: 16Gi
+    persistentvolumeclaims: "20"

--- a/flux/clusters/cumulus/applications/mattermost/deployment.yaml
+++ b/flux/clusters/cumulus/applications/mattermost/deployment.yaml
@@ -19,6 +19,13 @@ spec:
       - name: wait-for-db
         image: busybox:1.36
         command: ['sh', '-c', 'until nc -z mattermost-pg-rw 5432; do echo waiting for db; sleep 2; done;']
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
       containers:
       - name: mattermost
         image: mattermost/mattermost-team-edition:9.2

--- a/flux/clusters/cumulus/applications/mattermost/kustomization.yaml
+++ b/flux/clusters/cumulus/applications/mattermost/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: mattermost
 resources:
   - namespace.yaml
+  - resource-quota.yaml
   - postgresql-cluster.yaml
   - pvc.yaml
   - deployment.yaml

--- a/flux/clusters/cumulus/applications/mattermost/resource-quota.yaml
+++ b/flux/clusters/cumulus/applications/mattermost/resource-quota.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: compute-resources
+  namespace: mattermost
+spec:
+  hard:
+    requests.cpu: "2"
+    requests.memory: 4Gi
+    limits.cpu: "4"
+    limits.memory: 8Gi
+    persistentvolumeclaims: "10"

--- a/flux/clusters/cumulus/applications/nextcloud/deployment.yaml
+++ b/flux/clusters/cumulus/applications/nextcloud/deployment.yaml
@@ -19,6 +19,13 @@ spec:
       - name: wait-for-db
         image: busybox:1.36
         command: ['sh', '-c', 'until nc -z nextcloud-pg-rw 5432; do echo waiting for db; sleep 2; done;']
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
       containers:
       - name: nextcloud
         image: nextcloud:28-apache

--- a/flux/clusters/cumulus/applications/nextcloud/kustomization.yaml
+++ b/flux/clusters/cumulus/applications/nextcloud/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: nextcloud
 resources:
   - namespace.yaml
+  - resource-quota.yaml
   - postgresql-cluster.yaml
   - redis-cluster.yaml
   - oidc-config.yaml

--- a/flux/clusters/cumulus/applications/nextcloud/resource-quota.yaml
+++ b/flux/clusters/cumulus/applications/nextcloud/resource-quota.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: compute-resources
+  namespace: nextcloud
+spec:
+  hard:
+    requests.cpu: "2"
+    requests.memory: 4Gi
+    limits.cpu: "4"
+    limits.memory: 8Gi
+    persistentvolumeclaims: "10"

--- a/flux/clusters/cumulus/controllers/keycloak-operator/release.yaml
+++ b/flux/clusters/cumulus/controllers/keycloak-operator/release.yaml
@@ -111,3 +111,10 @@ spec:
               fieldPath: metadata.namespace
         - name: OPERATOR_KEYCLOAK_IMAGE
           value: quay.io/keycloak/keycloak:26.0.7
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi

--- a/flux/clusters/cumulus/services/keycloak/kustomization.yaml
+++ b/flux/clusters/cumulus/services/keycloak/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: keycloak
 resources:
   - namespace.yaml
+  - resource-quota.yaml
   - postgresql-cluster.yaml
   - keycloak-cr.yaml
   - realm-happyvertical.yaml

--- a/flux/clusters/cumulus/services/keycloak/resource-quota.yaml
+++ b/flux/clusters/cumulus/services/keycloak/resource-quota.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: compute-resources
+  namespace: keycloak
+spec:
+  hard:
+    requests.cpu: "2"
+    requests.memory: 4Gi
+    limits.cpu: "4"
+    limits.memory: 8Gi
+    persistentvolumeclaims: "10"


### PR DESCRIPTION
## Summary
- Adds resource limits to all init containers to prevent resource exhaustion
- Adds missing resource limits to Keycloak operator
- Implements ResourceQuotas for all application namespaces to enforce cluster-wide resource governance

## Changes Made

### Init Container Resource Limits
Added resource limits to `wait-for-db` init containers in:
- Nextcloud deployment
- Mattermost deployment

```yaml
resources:
  requests:
    cpu: 50m
    memory: 64Mi
  limits:
    cpu: 100m
    memory: 128Mi
```

### Operator Resource Limits
Added resource limits to Keycloak operator deployment:
```yaml
resources:
  requests:
    cpu: 100m
    memory: 256Mi
  limits:
    cpu: 500m
    memory: 512Mi
```

### Namespace ResourceQuotas
Created ResourceQuota manifests for all application namespaces:
- `nextcloud`: 2 CPU / 4Gi memory (requests), 4 CPU / 8Gi memory (limits)
- `mattermost`: 2 CPU / 4Gi memory (requests), 4 CPU / 8Gi memory (limits)
- `keycloak`: 2 CPU / 4Gi memory (requests), 4 CPU / 8Gi memory (limits)
- `mailu`: 4 CPU / 8Gi memory (requests), 8 CPU / 16Gi memory (limits)

## Test Plan
- [ ] Verify init containers start successfully with resource limits
- [ ] Confirm operators function normally with resource constraints
- [ ] Test that ResourceQuotas are enforced in each namespace
- [ ] Ensure existing applications continue to work within quotas

Fixes #23