### PR TITLE
Fix DNS resource inconsistency in Terraform

### DIFF
--- a/terraform/digitalocean/dns.tf
+++ b/terraform/digitalocean/dns.tf
@@ -26,7 +26,7 @@ locals {
 
 # DNS Records for services
 resource "digitalocean_record" "keycloak" {
-  domain = local.domain_name
+  domain = local.domain_id
   type   = "A"
   name   = "auth"
   value  = var.load_balancer_ip


### PR DESCRIPTION
Closes #22

## Problem Fixed
DNS records in terraform/digitalocean/dns.tf had inconsistent domain references:
- keycloak record used  (string)
- All other records used  (resource reference)

## Solution
- ✅ Standardized keycloak record to use  
- ✅ All DNS records now consistently reference the domain resource
- ✅ Prevents potential Terraform deployment failures
- ✅ Ensures proper resource dependencies

## Impact
- More reliable Terraform deployments
- Consistent resource dependency chain
- Reduced risk of DNS record creation failures

## Testing
- ✅ Verified all DNS records use consistent domain reference
- ✅ Confirmed outputs still correctly use domain_name for FQDNs
- ✅ No breaking changes to existing functionality