### PR TITLE
Add setup-project script for workflow initialization

### DIFF
--- a/scripts/setup-project
+++ b/scripts/setup-project
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Setup project with labels and project board following WORKFLOW.md
+
+set -e
+
+echo "Setting up project with Kanban workflow labels and project board..."
+
+# Create Status Labels
+echo "Creating status labels..."
+gh label create "status:new-issue" --color "#a2eeef" --description "A new, untriaged issue." --force
+gh label create "status:icebox" --color "#d876e3" --description "Valid issue, but not a current priority." --force
+gh label create "status:backlog" --color "#bfd4f2" --description "Prioritized and ready for consideration." --force
+gh label create "status:to-do" --color "#fef2c0" --description "Ready for active development." --force
+gh label create "status:in-progress" --color "#2a9d8f" --description "Actively being worked on." --force
+gh label create "status:code-review" --color "#f4a261" --description "Pull request is open and awaiting review." --force
+gh label create "status:testing" --color "#e9c46a" --description "In QA, undergoing automated/manual tests." --force
+gh label create "status:ready-for-deployment" --color "#6a48d9" --description "Passed all checks and is ready to be released." --force
+gh label create "status:deployed" --color "#4CAF50" --description "Work is live in production." --force
+
+# Create Type Labels
+echo "Creating type labels..."
+gh label create "type:bug" --color "#d73a4a" --description "An error or unintended behavior." --force
+gh label create "type:feature" --color "#0075ca" --description "A request for new functionality." --force
+gh label create "type:enhancement" --color "#a2eeef" --description "An improvement to an existing feature." --force
+gh label create "type:tech-debt" --color "#7057ff" --description "Necessary refactoring or infrastructure work." --force
+gh label create "type:epic" --color "#d876e3" --description "A large body of work." --force
+
+# Get repository owner
+REPO_OWNER=$(gh repo view --json owner --jq '.owner.login')
+
+# Create the project
+echo "Creating project board..."
+PROJECT_URL=$(gh project create --owner "$REPO_OWNER" --title "Kanban Board" --format json | jq -r '.url')
+PROJECT_NUMBER=$(echo "$PROJECT_URL" | grep -o '[0-9]*$')
+
+echo "Project created: $PROJECT_URL"
+echo "Project number: $PROJECT_NUMBER"
+
+# Create the "Status" field with all its options
+echo "Creating Status field with options..."
+gh project field-create "$PROJECT_NUMBER" --owner "$REPO_OWNER" --name "Status" \
+--data-type "SINGLE_SELECT" \
+--single-select-options "New Issues,Icebox,Backlog,To Do,In Progress,Code Review,Testing,Ready for Deployment,Deployed"
+
+echo "✅ Project setup complete!"
+echo "Project URL: $PROJECT_URL"
+echo "Next steps:"
+echo "1. Add the automation workflow .github/workflows/label-to-status.yml"
+echo "2. Replace YOUR_PROJECT_NUMBER with $PROJECT_NUMBER in the workflow file"


### PR DESCRIPTION
Adds automated setup script for Kanban workflow labels and project board.

- Creates status labels (new-issue, icebox, backlog, etc.)
- Creates type labels (bug, feature, enhancement, etc.)  
- Sets up GitHub project board with Status field
- One-command project initialization

Usage: ./scripts/setup-project