### PR TITLE
feat: add gameplan requirement to issue workflow

### DIFF
--- a/.claude/commands/issue.md
+++ b/.claude/commands/issue.md
@@ -41,21 +41,24 @@ When passed an issue number:
 - Decision: close as stale, keep in icebox with update, or move to backlog
 
 **BACKLOG:**
-- Check Definition of Ready (acceptance criteria, estimates, no blockers)
+- Check Definition of Ready (acceptance criteria, estimates, gameplan, no blockers)
 - Look for clarifying comments
 - If acceptance criteria missing: analyze issue and generate reasonable defaults based on problem description and proposed solution
 - If estimation missing: provide complexity estimate (S/M/L) based on scope analysis
+- If implementation gameplan missing: create detailed gameplan comment on issue outlining approach, key changes, and considerations
 - Decision: request missing info or move to todo
 - If Definition of Ready is met: automatically progress to todo
 - If not ready to progress: add comment explaining what's needed for Definition of Ready
 
 **TO-DO:**
-- Add implementation plan as comment if one doesn't exist
-- If confidence in approach is low: add comment explaining concerns and questions
-- Automatically assign to self
-- Create feature branch (`issue-<number>`)
-- Move to in-progress  
-- Immediately begin full implementation (analyze codebase, implement solution, write tests, prepare for review)
+- Review existing implementation gameplan from backlog stage
+- If clarification needed on gameplan: add comment with questions for discussion
+- Wait for gameplan finalization if questions exist
+- Once gameplan is finalized:
+  - Create feature branch from main (`feature/<issue-description>`)
+  - Automatically assign to self
+  - Move to in-progress  
+  - Begin full implementation following the agreed gameplan
 
 **IN-PROGRESS:**
 - Check for review comments or feedback

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -232,15 +232,18 @@ graph TD
     C -- Yes --> D[Analyze issue and generate reasonable defaults];
     C -- No --> E{Missing estimation?};
     E -- Yes --> F[Provide complexity estimate based on scope];
-    E -- No --> G[Comment explaining other missing requirements];
-    D --> H[Add generated criteria and estimation];
-    F --> H;
-    H --> I{Now meets Definition of Ready?};
-    I -- Yes --> J[Auto-progress to 'To Do'];
-    I -- No --> G;
-    B -- Yes --> K{Are all questions answered?};
-    K -- No --> L[Comment to Clarify Remaining Questions];
-    K -- Yes --> J;
+    E -- No --> G{Missing implementation gameplan?};
+    G -- Yes --> H[Create gameplan comment on issue];
+    G -- No --> I[Comment explaining other missing requirements];
+    D --> J[Add generated criteria and estimation];
+    F --> J;
+    H --> J;
+    J --> K{Now meets Definition of Ready?};
+    K -- Yes --> L[Auto-progress to 'To Do'];
+    K -- No --> I;
+    B -- Yes --> M{Are all questions answered?};
+    M -- No --> N[Comment to Clarify Remaining Questions];
+    M -- Yes --> L;
 ```
 
 ## 4. Development & CI/CD Lanes
@@ -249,15 +252,20 @@ These lanes represent the active workflow for developing, testing, and deploying
 
 ### 4.1. To Do / Ready for Dev
 
-This lane contains fully refined and prioritized issues that are ready for a developer to begin working on.
+This lane contains fully refined and prioritized issues that are ready for a developer to begin working on. Each issue should have an implementation gameplan already established.
 ```mermaid
 graph TD
     A[Ready for New Work] --> B[Select Highest Priority Issue from 'To Do'];
-    B --> C[Add Implementation Plan if Missing];
-    C --> D{High confidence in approach?};
-    D -- No --> E[Comment explaining concerns and questions];
-    D -- Yes --> F[Assign Issue to Self];
-    F --> G[Move Issue to 'In Progress'];
+    B --> C{Review implementation gameplan};
+    C --> D{Need clarification on gameplan?};
+    D -- Yes --> E[Comment questions on issue for discussion];
+    E --> F{Gameplan finalized?};
+    F -- No --> E;
+    F -- Yes --> G[Create feature branch from main];
+    D -- No --> G;
+    G --> H[Name branch: feature/issue-description];
+    H --> I[Assign Issue to Self];
+    I --> J[Move Issue to 'In Progress'];
 ```
 
 ### 4.2. In Progress
@@ -265,7 +273,7 @@ graph TD
 This is the active development stage. The goal is to write high-quality code, create corresponding tests, and prepare the work for a peer review.
 ```mermaid
 graph TD
-    A[Issue in 'In Progress'] --> B[Create New Feature Branch from `main`];
+    A[Issue in 'In Progress'] --> B[Switch to feature branch];
     B --> C[Write Code & Corresponding Unit/Integration Tests];
     C --> D{Does code pass all local tests?};
     D -- No --> C;


### PR DESCRIPTION
## Summary
- Adds requirement for implementation gameplans before starting work on issues
- Ensures feature branches are created before development begins
- Promotes better planning and discussion before implementation

## Changes
- ✅ Updated WORKFLOW.md to include gameplan requirement in backlog stage
- ✅ Added gameplan discussion/finalization phase in todo stage
- ✅ Modified branch creation to happen when transitioning from todo to in-progress
- ✅ Updated .claude/commands/issue.md to reflect new workflow requirements

## Benefits
- 📋 Better planning before implementation starts
- 💬 Encourages discussion and alignment on approach
- 🌳 Ensures consistent branch creation before development
- 🎯 Reduces rework by clarifying implementation approach upfront

## Workflow Impact
1. Issues in backlog now require a gameplan comment before moving to todo
2. Issues in todo allow for gameplan discussion/refinement
3. Feature branches are created only after gameplan is finalized
4. Development starts with clear direction and approach

This maintains synchronization between WORKFLOW.md and .claude/commands/issue.md as required.