### PR TITLE
feat: enforce conventional commits

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Conventional Commits hook
+# https://www.conventionalcommits.org/
+
+commit_regex='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .{1,50}'
+
+if ! grep -qE "$commit_regex" "$1"; then
+    echo "❌ Commit message does not follow Conventional Commits format!"
+    echo ""
+    echo "Format: <type>(<scope>): <subject>"
+    echo ""
+    echo "Types:"
+    echo "  feat:     New feature"
+    echo "  fix:      Bug fix"
+    echo "  docs:     Documentation only changes"
+    echo "  style:    Code style changes (formatting, semicolons, etc)"
+    echo "  refactor: Code change that neither fixes a bug nor adds a feature"
+    echo "  perf:     Performance improvements"
+    echo "  test:     Adding or correcting tests"
+    echo "  build:    Changes to build system or dependencies"
+    echo "  ci:       CI configuration files and scripts"
+    echo "  chore:    Other changes that don't modify src or test files"
+    echo "  revert:   Reverts a previous commit"
+    echo ""
+    echo "Example: feat(auth): add OAuth2 login support"
+    echo ""
+    echo "Your commit message:"
+    echo "$(cat "$1")"
+    exit 1
+fi
+
+# Check message length
+subject=$(head -n1 "$1" | sed 's/^[^:]*: //')
+if [ ${#subject} -gt 72 ]; then
+    echo "❌ Commit subject is too long (${#subject} chars, max 72)"
+    exit 1
+fi

--- a/.github/workflows/setup-form.yml
+++ b/.github/workflows/setup-form.yml
@@ -25,7 +25,7 @@ jobs:
           
           # Create issue for setup-repo.sh execution
           gh issue create \
-            --title "Repository Setup Required" \
+            --title "chore: configure repository from template" \
             --body "$(cat <<'EOF'
           ## 🚀 Repository Setup Required
 

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -410,7 +410,7 @@ See [WORKFLOW.md](./WORKFLOW.md) for detailed workflow documentation.
     # Try to create GitHub issue if gh CLI is available
     if command -v gh >/dev/null 2>&1; then
         if gh issue create \
-            --title "Template Cleanup and Eject" \
+            --title "chore: complete template cleanup and ejection" \
             --body "$issue_body" \
             --label "template-cleanup" 2>/dev/null; then
             echo -e "${GREEN}✓ GitHub issue created successfully${NC}"


### PR DESCRIPTION
## Summary
- Add commit-msg git hook to validate commit messages
- Update workflow issue titles to follow conventional format
- Configure repository to use .githooks directory

## Changes
1. **Added `.githooks/commit-msg`**: Validates commit messages against conventional commits format
   - Enforces type prefixes (feat, fix, docs, etc.)
   - Limits subject line to 72 characters
   - Provides helpful error messages

2. **Updated issue titles in workflows**:
   - `.github/workflows/setup-form.yml`: "Repository Setup Required" → "chore: configure repository from template"
   - `setup-repo.sh`: "Template Cleanup and Eject" → "chore: complete template cleanup and ejection"

3. **Configured git**: Set `core.hooksPath` to `.githooks`

## Testing
The hook has been tested with:
- ❌ Invalid format: "bad commit message"
- ✅ Valid format: "test: add test file"
- ❌ Too long subject: 93 chars when max is 72

## Benefits
- Consistent commit history
- Better automated changelog generation
- Clear communication of change types
- Improved searchability of commits