### PR TITLE
fix: add null checks before trim() calls in PR creation logic

### DIFF
--- a/setup.ts
+++ b/setup.ts
@@ -370,7 +370,8 @@ class GitOpsSetup {
     if (!this.options.skipGithub) {
       try {
         // GitHub account info
-        const ghUser = this.exec('gh api user --jq .login', true).trim();
+        const ghUserResult = this.exec('gh api user --jq .login', true);
+        const ghUser = ghUserResult ? ghUserResult.trim() : 'Unknown';
         const repoInfo = this.exec('gh repo view --json owner,name', true);
         const repo = JSON.parse(repoInfo);
         const repoName = `${repo.owner.login}/${repo.name}`;
@@ -1065,7 +1066,7 @@ ${optionalFiles.filter(f => existsSync(f)).map(f => `- \`${f}\``).join('\n')}`;
     try {
       // Check if there are any git changes
       const status = this.exec('git status --porcelain', true);
-      if (!status.trim()) {
+      if (!status || !status.trim()) {
         this.log('No changes to commit, skipping PR creation');
         return;
       }


### PR DESCRIPTION
## Summary
Fixes the null reference error in PR creation logic that was causing setup.ts to crash with "Cannot read properties of null (reading 'trim')".

Fixes #105

## Problem
The PR creation feature introduced in #104 had a critical bug where `.trim()` was being called on potentially null values returned by the `exec()` method, causing crashes during setup.

## Root Cause
Two locations in the code were calling `.trim()` without proper null checks:
1. `git status --porcelain` result validation (line 1068)
2. GitHub user API call result (line 373)

## Solution
### Added Null Safety Checks
- **Git status validation**: Added `\!status ||` check before `\!status.trim()`
- **GitHub user API**: Extract result to variable and null-check before trimming
- **Graceful fallbacks**: Use 'Unknown' as fallback for GitHub user when API fails

### Code Changes
```typescript
// Before (problematic)
if (\!status.trim()) {

// After (safe)
if (\!status || \!status.trim()) {
```

```typescript
// Before (problematic)  
const ghUser = this.exec('gh api user --jq .login', true).trim();

// After (safe)
const ghUserResult = this.exec('gh api user --jq .login', true);
const ghUser = ghUserResult ? ghUserResult.trim() : 'Unknown';
```

## Test Plan
- [x] TypeScript compilation passes
- [x] Identified and fixed both problematic locations
- [x] Added proper fallback values for null cases
- [ ] Test with repository that has no git changes
- [ ] Test with GitHub CLI authentication failures

## Impact
- ✅ Prevents crashes during PR creation
- ✅ Maintains existing functionality with better error handling
- ✅ No breaking changes - purely defensive programming

## Files Changed
- `setup.ts` - Added null checks before `.trim()` calls in PR creation and account info logic

This is a critical fix for the regression introduced in the PR creation feature.